### PR TITLE
Chromium: Take screenshot when body is ready

### DIFF
--- a/chromium/chromium.go
+++ b/chromium/chromium.go
@@ -85,6 +85,7 @@ func takeScreenshot(res *[]byte, html string, width float64, height float64) chr
 			return nil
 
 		}),
+		chromedp.WaitReady("body"),
 		chromedp.ActionFunc(func(ctx context.Context) error {
 
 			_, _, contentSize, err := page.GetLayoutMetrics().Do(ctx)


### PR DESCRIPTION
This should wait for all images to be loaded before taking a screenshot